### PR TITLE
Use dedicated copr for PackIt

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,8 @@ jobs:
 - job: copr_build
   trigger: commit
   metadata:
+    owner: "@meta"
+    project: netconsd
     targets:
       - fedora-all-aarch64
       - fedora-all-armhfp
@@ -23,6 +25,11 @@ jobs:
       - fedora-all-ppc64le
       - fedora-all-s390x
       - fedora-all-x86_64
+      - fedora-eln-aarch64
+      - fedora-eln-i386
+      - fedora-eln-ppc64le
+      - fedora-eln-s390x
+      - fedora-eln-x86_64
       - epel-8-aarch64
       - epel-8-ppc64le
       - epel-8-s390x
@@ -34,6 +41,8 @@ jobs:
 - job: copr_build
   trigger: pull_request
   metadata:
+    owner: "@meta"
+    project: netconsd
     targets:
       - fedora-all-aarch64
       - fedora-all-armhfp
@@ -41,6 +50,11 @@ jobs:
       - fedora-all-ppc64le
       - fedora-all-s390x
       - fedora-all-x86_64
+      - fedora-eln-aarch64
+      - fedora-eln-i386
+      - fedora-eln-ppc64le
+      - fedora-eln-s390x
+      - fedora-eln-x86_64
       - epel-8-aarch64
       - epel-8-ppc64le
       - epel-8-s390x


### PR DESCRIPTION
Summary: Generated builds should show up at https://copr.fedorainfracloud.org/coprs/g/meta/netconsd/

Differential Revision: D35651371

