### PR TITLE
Update all copyright/license headers with current template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016 Facebook
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 use std::process::Command;

--- a/include/common.h
+++ b/include/common.h
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #ifndef __COMMON_H__

--- a/include/jhash.h
+++ b/include/jhash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Lifted from 4.4 Linux kernel source. Alterations for netconsd:
  *	- Pulled in rol32() from linux/bitops.h

--- a/include/listener.h
+++ b/include/listener.h
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #ifndef __LISTENER_H__

--- a/include/log.h
+++ b/include/log.h
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 #ifndef __LOG_H__
 #define __LOG_H__

--- a/include/msgbuf-struct.h
+++ b/include/msgbuf-struct.h
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #ifndef __MSGBUF_STRUCT_H__

--- a/include/output.h
+++ b/include/output.h
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #ifndef __OUTPUT_H__

--- a/include/threads.h
+++ b/include/threads.h
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #ifndef __NCRX_THREADS_H__

--- a/include/worker.h
+++ b/include/worker.h
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #ifndef __WORKER_H__

--- a/listener.c
+++ b/listener.c
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * file in the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/main.c
+++ b/main.c
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/main.rs
+++ b/main.rs
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 use anyhow::bail;

--- a/modules/logger.cc
+++ b/modules/logger.cc
@@ -1,10 +1,9 @@
 /* logger.cc: Very simple example C++ netconsd module
  *
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <cerrno>

--- a/modules/printer.c
+++ b/modules/printer.c
@@ -1,10 +1,9 @@
 /* printer.c: Very simple example C netconsd module
  *
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/ncrx/libncrx.c
+++ b/ncrx/libncrx.c
@@ -1,11 +1,10 @@
 /*
  * ncrx - extended netconsole receiver library
  *
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdbool.h>

--- a/ncrx/ncrx-struct.h
+++ b/ncrx/ncrx-struct.h
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #ifndef __NETCONSOLE_NCRX_STRUCT__

--- a/ncrx/ncrx.c
+++ b/ncrx/ncrx.c
@@ -1,11 +1,10 @@
 /*
  * ncrx - simple extended netconsole receiver
  *
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/ncrx/ncrx.h
+++ b/ncrx/ncrx.h
@@ -1,11 +1,10 @@
 /*
  * ncrx - extended netconsole receiver library
  *
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #ifndef __NETCONSOLE_NCRX__

--- a/ncrx/nctx.c
+++ b/ncrx/nctx.c
@@ -1,11 +1,10 @@
 /*
  * nctx - extended netconsole sender
  *
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/ncrx/netcons-gen.py
+++ b/ncrx/netcons-gen.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2016-present, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
-# This source code is licensed under the license found in the LICENSE file in
-# the root directory of this source tree.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 #
 
 """

--- a/output.c
+++ b/output.c
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/rust/blaster/src/lib.rs
+++ b/rust/blaster/src/lib.rs
@@ -2,11 +2,10 @@
  * Utility functions to send fake netconsole messages, can be used to test
  * netconsd and its modules.
  *
- * Copyright (C) 2022, Meta, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 use std::io::Cursor;
 use std::mem::size_of;

--- a/rust/blaster/src/main.rs
+++ b/rust/blaster/src/main.rs
@@ -1,11 +1,10 @@
 /*
  * Simple utility that sends netconsole messages to localhost.
  *
- * Copyright (C) 2022, Meta, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 use std::thread;
 use std::time::Duration;

--- a/rust/example_module/src/lib.rs
+++ b/rust/example_module/src/lib.rs
@@ -1,11 +1,10 @@
 /*
  * A minimal example of a Rust netconsd module.
  *
- * Copyright (C) 2022, Meta, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 use netconsd_module::c_int;

--- a/rust/module/src/lib.rs
+++ b/rust/module/src/lib.rs
@@ -2,11 +2,10 @@
  * These structs have been generated with bindgen (except for the bitfields getters),
  * and are passed to netconsd_output_handler function defined in a netconsd module.
  *
- * Copyright (C) 2022, Meta, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 use std::ffi::CStr;

--- a/rust/self_test_module/src/lib.rs
+++ b/rust/self_test_module/src/lib.rs
@@ -3,11 +3,10 @@
  * receives all the messages.
  * E.g. ./netconsd -w 2 -l 2 -u 6666 self_test_module.so
  *
- * Copyright (C) 2022, Meta, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 use std::ffi::CStr;
 use std::os::raw::c_char;

--- a/threads.c
+++ b/threads.c
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/util/netconsblaster.c
+++ b/util/netconsblaster.c
@@ -1,11 +1,10 @@
 /*
  * netconsblaster: A test excerciser for netconsd and libncrx
  *
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/worker.c
+++ b/worker.c
@@ -1,9 +1,8 @@
 /*
- * Copyright (C) 2016, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include <stdlib.h>


### PR DESCRIPTION
1. Facebook -> Meta Platforms
2. Meta -> Meta Platforms
3. Remove years (as is our approach now since people tend not to update these correctly anyway and we have commit history for accurate dates)
4. Reference BSD directly in the license header (helps with the case of people using a single file and attributing correctly).