### PR TITLE
Portability fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 
-LIBS = -lpthread -lrt -ldl
+LIBS = -lpthread
 CFLAGS ?= -O2 -fPIC
 CFLAGS += -D_GNU_SOURCE -fno-strict-aliasing -Wall -Wextra \
           -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations \
@@ -8,6 +8,11 @@ CFLAGS += -D_GNU_SOURCE -fno-strict-aliasing -Wall -Wextra \
           -Wno-unused-parameter
 CPPFLAGS ?=
 INCLUDES = -Incrx
+
+UNAME := $(shell uname)
+ifneq ($(UNAME), OpenBSD)
+LIBS += -lrt -ldl
+endif
 
 debug debug32: CFLAGS += -O0 -gdwarf-4 -fno-omit-frame-pointer \
 	                 -fstack-protector-all -fsanitize=address \

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ own custom output module.
 ## Building netconsd
 
 The default Makefile target intended for production use has no external
-dependencies besides glibc. To build it, just say `make`: you'll end up with a
-single executable in this directory called `netconsd`, and a `*.so` file for every
-module in the `modules/` directory.
+dependencies besides glibc. To build it, just say `make` (or `gmake` on BSD):
+you'll end up with a single executable in this directory called `netconsd`, and
+a `*.so` file for every module in the `modules/` directory.
 
 The Makefile includes a few other handy targets:
 

--- a/include/listener.h
+++ b/include/listener.h
@@ -9,6 +9,7 @@
 #define __LISTENER_H__
 
 #include "threads.h"
+#include <pthread.h>
 
 #define RCVBUF_SIZE	1024
 

--- a/listener.c
+++ b/listener.c
@@ -124,7 +124,7 @@ static int get_listen_socket(struct sockaddr_in6 *bindaddr)
 	if (ret == -1)
 		fatal("Couldn't set SO_REUSEPORT on socket: %m\n");
 
-	ret = bind(fd, bindaddr, sizeof(*bindaddr));
+	ret = bind(fd, (const struct sockaddr *)bindaddr, sizeof(*bindaddr));
 	if (ret == -1)
 		fatal("Couldn't bind: %m\n");
 

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -5,7 +5,7 @@ LDFLAGS ?=
 
 override CFLAGS += -fPIC
 override CXXFLAGS += -std=c++11 -fPIC
-override LDFLAGS += -shared -static-libstdc++ -static-libgcc
+override LDFLAGS += -shared
 INCLUDES = -I../ncrx -I../include
 
 mods = printer.so logger.so
@@ -13,11 +13,11 @@ mods = printer.so logger.so
 all: $(mods)
 
 %.so: %.c
-	$(CC) $< $(CPPFLAGS) $(CFLAGS) $(INCLUDES) $(LDFLAGS) -c -o $(<:.c=.o)
+	$(CC) $< $(CPPFLAGS) $(CFLAGS) $(INCLUDES) -c -o $(<:.c=.o)
 	$(CC) $(<:.c=.o) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@
 
 %.so: %.cc
-	$(CXX) $< $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) $(LDFLAGS) -c -o $(<:.cc=.o)
+	$(CXX) $< $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c -o $(<:.cc=.o)
 	$(CXX) $(<:.cc=.o) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@
 
 clean:


### PR DESCRIPTION
Seven fixes for minor issues which show up on BSD and linux+musl:

	1) Add missing "#include <pthread.h>" in a header file.

	2) Add two missing casts for struct sockaddr.

	3) Work around missing dlinfo() on OpenBSD by saving the module
	   paths at open time instead of looking them up later with
	   RTLD_DI_ORIGIN. This also fixes musl. The names are only
	   cosmetic, so if they are subtly different it doesn't matter.

	4) Omit the -lrt and -ldl flags on OpenBSD.

	5) Use <inttypes.h> printf macros and portable udp field names
	   in netconsblaster.

	6) Unfortunately, (5) isn't enough: the runtime semantics of
	   SOCK_RAW are completely different on *BSD, and nothing works.
	   For now, just emit a compile error in netconsblaster for the
	   !linux case. But keep (5) since it's a nice cleanup.

	7) Drop -static-libgcc and -static-libstdc++ from the LDFLAGS in
	   the modules, since they cause errors on musl and don't seem
	   to be necessary on any platform. Also, don't pass LDFLAGS to
	   the compile call, since it causes clang to emit warnings.