### PR TITLE
fix: existing log files being truncated on restart

### DIFF
--- a/logrotate/netconsd
+++ b/logrotate/netconsd
@@ -1,0 +1,14 @@
+/var/log/netconsd/*[!g][!z] {
+        compress
+        compressext .gz
+        compresscmd /usr/bin/gzip
+        uncompresscmd /usr/bin/gunzip
+        missingok
+        copytruncate
+        daily
+        rotate 31
+        minsize 2048
+        notifempty
+        dateext
+        dateformat .%Y-%m-%d.log
+}

--- a/modules/logger-advanced.cc
+++ b/modules/logger-advanced.cc
@@ -96,7 +96,7 @@ struct logtarget {
 			}
 		}
 
-		ret = open(hostname, O_TRUNC | O_WRONLY | O_CREAT, 0644);
+		ret = open(hostname, O_APPEND | O_WRONLY | O_CREAT, 0644);
 		if (ret == -1) {
 			fprintf(stderr, "FATAL: open() failed: %m\n");
 			abort();

--- a/modules/logger-simple.cc
+++ b/modules/logger-simple.cc
@@ -85,7 +85,7 @@ struct logtarget {
 			}
 		}
 
-		ret = open(hostname, O_TRUNC | O_WRONLY | O_CREAT, 0644);
+		ret = open(hostname, O_APPEND | O_WRONLY | O_CREAT, 0644);
 		if (ret == -1) {
 			fprintf(stderr, "FATAL: open() failed: %m\n");
 			abort();


### PR DESCRIPTION
The existing modules pass `O_TRUNC` flag to `open()` for opening the (usually pre-existing) logfiles.
This results in all existing log entries to be discarded.

This PR changes O_TRUNC to O_APPEND.
It also add an example logrotate config file.
